### PR TITLE
Remove post_install step

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,8 +54,6 @@ brews:
       system "#{bin}/cloudagent"
     install: |
       bin.install "cloudagent"
-    post_install: |
-      system "make", "bootstrap-config"
     service: |
       run ["#{opt_bin}/cloudagent", "serve"]
       log_path "/tmp/cloudagent/cloudagent.stdout"


### PR DESCRIPTION
**Description:**

Remove the `post_install` target because it's not needed and it's blocking installation on M1 MacBooks