### PR TITLE
Rancher and Krew support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,7 +57,7 @@ brews:
     service: |
       run ["#{opt_bin}/cloudagent", "serve"]
       log_path "/tmp/cloudagent/cloudagent.stdout"
-      environment_variables PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:#{Dir.home}/.rd/bin:#{Dir.home}/.krew/bin"
+      environment_variables PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:#{Dir.home}/.rd/bin:#{Dir.home}/.krew/bin:"
       keep_alive true
 
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,7 +57,7 @@ brews:
     service: |
       run ["#{opt_bin}/cloudagent", "serve"]
       log_path "/tmp/cloudagent/cloudagent.stdout"
-      environment_variables PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:"
+      environment_variables PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:#{Dir.home}/.rd/bin:#{Dir.home}/.krew/bin"
       keep_alive true
 
 checksum:


### PR DESCRIPTION
**Description:**

Rancher Desktop installs the kubectl under the `$HOME/.rd/bin` folder same as the krew which installs plugins under the `$HOME/.krew/bin` folder. This PR add these paths to the cloudagent PATH env